### PR TITLE
課題レビュー中にコメント入力に飛べるページ内リンクを表示する

### DIFF
--- a/mentor_check_ex/css/review_skip2reviewcomment.css
+++ b/mentor_check_ex/css/review_skip2reviewcomment.css
@@ -1,0 +1,14 @@
+.mce-skiplink {
+    display: inline-block;
+    background-color: #0f7378;
+    color: #fff;
+    padding: 10px 20px;
+    border-radius: 5px;
+    margin-bottom: 20px;
+    transition: all .5s;
+}
+
+.mce-skiplink:hover {
+    background-color: #78bd78;
+    color: #fff;
+}

--- a/mentor_check_ex/js/review_skip2reviewcomment.js
+++ b/mentor_check_ex/js/review_skip2reviewcomment.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const MES2RC = new MentorCheckEx();
+
+// 課題のID取得
+const reviewHeading = MES2RC.query('#page-content-wrapper .container-fluid .row .row.add-margin-top-30 .col-sm-8 h3');
+const reviewNum = reviewHeading.innerText.match(/\d+/);
+const reviewId = 'edit_report_' + reviewNum;
+
+// レビュー中（フォームのIDが存在する）ならリンクを追加
+if (MES2RC.queryId(reviewId) != null) {
+
+    // リンクの作成
+    const skipLink = MCEElement.create('a').prop({ href: '#' + reviewId}).addClass('mce-skiplink').text('評価コメントまでスキップする');
+
+    // リンクの差し込み
+    MES2RC.query('#page-content-wrapper .container-fluid .row .col-lg-12 .row.add-margin-top-30 .col-sm-8').prepend(skipLink.get());
+
+}

--- a/mentor_check_ex/manifest.json
+++ b/mentor_check_ex/manifest.json
@@ -94,6 +94,12 @@
          "js": ["js/work_shifts.js"]
       },
       {
+         "matches": ["https://techacademy.jp/mentor/reports/*"],
+         "run_at": "document_end",
+         "js": ["js/review_skip2reviewcomment.js"],
+         "css": ["css/review_skip2reviewcomment.css"]
+      },
+      {
          "matches": ["https://techacademy.jp/mentor/courses/*/review_guide"],
          "run_at": "document_end",
          "js": ["js/review_criteria.js"],


### PR DESCRIPTION
主に専任制で、内容確認済のためにいきなりレビューコメントの入力に飛びたいことがあります。   
そのニーズに応えるページ内リンクを表示する機能を追加しました。